### PR TITLE
Suffix const for selector methods and parameters

### DIFF
--- a/src/CameraServer.cpp
+++ b/src/CameraServer.cpp
@@ -30,7 +30,7 @@
 #define DEFAULT_SERVICE_PORT 8554
 
 #ifdef ENABLE_MAVLINK
-CameraServer::CameraServer(ConfFile &conf)
+CameraServer::CameraServer(const ConfFile &conf)
     : mavlink_server(conf, streams, rtsp_server)
     , rtsp_server(streams, DEFAULT_SERVICE_PORT)
     , cameraCount(0)
@@ -70,7 +70,7 @@ CameraServer::CameraServer(ConfFile &conf)
     }
 }
 #else
-CameraServer::CameraServer(ConfFile &conf)
+CameraServer::CameraServer(const ConfFile &conf)
     : rtsp_server(streams, DEFAULT_SERVICE_PORT)
     , cameraCount(0)
 {
@@ -117,7 +117,7 @@ void CameraServer::stop()
 }
 
 // prepare the list of cameras in the system
-int CameraServer::detectCamera(ConfFile &conf)
+int CameraServer::detectCamera(const ConfFile &conf)
 {
     int count = 0;
 
@@ -136,7 +136,8 @@ int CameraServer::detectCamera(ConfFile &conf)
 }
 
 #ifdef ENABLE_GAZEBO
-int CameraServer::detect_devices_gazebo(ConfFile &conf, std::vector<CameraComponent *> &camList)
+int CameraServer::detect_devices_gazebo(const ConfFile &conf,
+                                        std::vector<CameraComponent *> &camList) const
 {
     char *uri_addr = 0;
     std::string camTopic = getGazeboCamTopic(conf);
@@ -158,7 +159,8 @@ int CameraServer::detect_devices_gazebo(ConfFile &conf, std::vector<CameraCompon
 }
 #endif
 
-int CameraServer::detect_devices_v4l2(ConfFile &conf, std::vector<CameraComponent *> &camList)
+int CameraServer::detect_devices_v4l2(const ConfFile &conf,
+                                      std::vector<CameraComponent *> &camList) const
 {
     int count = 0;
     char *uri_addr = 0;
@@ -197,7 +199,7 @@ int CameraServer::detect_devices_v4l2(ConfFile &conf, std::vector<CameraComponen
     return count;
 }
 
-std::string CameraServer::getImgCapLocation(ConfFile &conf)
+std::string CameraServer::getImgCapLocation(const ConfFile &conf) const
 {
     // Location must start and end with "/"
     char *imgPath = 0;
@@ -214,7 +216,7 @@ std::string CameraServer::getImgCapLocation(ConfFile &conf)
     return ret;
 }
 
-int CameraServer::getVidCapSettings(ConfFile &conf, VideoSettings &vidSetting)
+int CameraServer::getVidCapSettings(const ConfFile &conf, VideoSettings &vidSetting) const
 {
     int ret = 0;
 
@@ -253,7 +255,7 @@ int CameraServer::getVidCapSettings(ConfFile &conf, VideoSettings &vidSetting)
     return ret;
 }
 
-std::string CameraServer::getVidCapLocation(ConfFile &conf)
+std::string CameraServer::getVidCapLocation(const ConfFile &conf) const
 {
     // Location must start and end with "/"
     char *vidPath = 0;
@@ -270,7 +272,7 @@ std::string CameraServer::getVidCapLocation(ConfFile &conf)
     return ret;
 }
 
-std::string CameraServer::getGazeboCamTopic(ConfFile &conf)
+std::string CameraServer::getGazeboCamTopic(const ConfFile &conf) const
 {
     // Location must start and end with "/"
     char *topic = 0;

--- a/src/CameraServer.h
+++ b/src/CameraServer.h
@@ -34,22 +34,22 @@
 
 class CameraServer {
 public:
-    CameraServer(ConfFile &conf);
+    CameraServer(const ConfFile &conf);
     ~CameraServer();
     void start();
     void stop();
-    int getCameraCount() { return cameraCount; }
+    int getCameraCount() const { return cameraCount; }
 
 private:
-    int getVidCapSettings(ConfFile &conf, VideoSettings &vidSetting);
-    std::string getVidCapLocation(ConfFile &conf);
-    std::string getImgCapLocation(ConfFile &conf);
-    std::string getGazeboCamTopic(ConfFile &conf);
-    int detectCamera(ConfFile &conf);
+    int getVidCapSettings(const ConfFile &conf, VideoSettings &vidSetting) const;
+    std::string getVidCapLocation(const ConfFile &conf) const;
+    std::string getImgCapLocation(const ConfFile &conf) const;
+    std::string getGazeboCamTopic(const ConfFile &conf) const;
+    int detectCamera(const ConfFile &conf);
 #ifdef ENABLE_GAZEBO
-    int detect_devices_gazebo(ConfFile &conf, std::vector<CameraComponent *> &camList);
+    int detect_devices_gazebo(const ConfFile &conf, std::vector<CameraComponent *> &camList) const;
 #endif
-    int detect_devices_v4l2(ConfFile &conf, std::vector<CameraComponent *> &cameraList);
+    int detect_devices_v4l2(const ConfFile &conf, std::vector<CameraComponent *> &cameraList) const;
 #ifdef ENABLE_MAVLINK
     MavlinkServer mavlink_server;
 #endif

--- a/src/conf_file.cpp
+++ b/src/conf_file.cpp
@@ -329,7 +329,7 @@ static void print_filenames(struct section *s)
 }
 
 int ConfFile::_extract_options_from_section(struct section *s, const OptionsTable table[],
-                                            size_t table_len, void *data)
+                                            size_t table_len, void *data) const
 {
     struct config *c;
     int ret;
@@ -360,7 +360,7 @@ int ConfFile::_extract_options_from_section(struct section *s, const OptionsTabl
 }
 
 int ConfFile::extract_options(const char *section_name, const OptionsTable table[],
-                              size_t table_len, void *data)
+                              size_t table_len, void *data) const
 {
     struct section *s;
 
@@ -385,7 +385,7 @@ int ConfFile::extract_options(const char *section_name, const OptionsTable table
 }
 
 int ConfFile::extract_options(struct section_iter *iter, const OptionsTable table[],
-                              size_t table_len, void *data)
+                              size_t table_len, void *data) const
 {
     assert(iter);
     assert(table);
@@ -393,7 +393,7 @@ int ConfFile::extract_options(struct section_iter *iter, const OptionsTable tabl
     return _extract_options_from_section((struct section *)iter->ptr, table, table_len, data);
 }
 
-int ConfFile::extract_options(const char *section_name, const char *key, char **value)
+int ConfFile::extract_options(const char *section_name, const char *key, char **value) const
 {
     assert(section_name);
     assert(key);
@@ -414,7 +414,7 @@ int ConfFile::extract_options(const char *section_name, const char *key, char **
     return ret;
 }
 
-struct config *ConfFile::_find_config(struct section *s, const char *key, size_t key_len)
+struct config *ConfFile::_find_config(struct section *s, const char *key, size_t key_len) const
 {
     struct config *c;
 
@@ -426,7 +426,7 @@ struct config *ConfFile::_find_config(struct section *s, const char *key, size_t
     return nullptr;
 }
 
-struct section *ConfFile::_find_section(const char *section_name, size_t len)
+struct section *ConfFile::_find_section(const char *section_name, size_t len) const
 {
     struct section *s;
 

--- a/src/conf_file.h
+++ b/src/conf_file.h
@@ -85,7 +85,7 @@ public:
      * @param data A pointer to the struct that will be used to hold the extracted data.
      */
     int extract_options(const char *section_name, const OptionsTable table[], size_t table_len,
-                        void *data);
+                        void *data) const;
 
     /**
      * Extract options set in @a table from section @a iter
@@ -99,7 +99,7 @@ public:
      * @see get_sections()
      */
     int extract_options(struct section_iter *iter, const OptionsTable table[], size_t table_len,
-                        void *data);
+                        void *data) const;
 
     /**
      * Extract option set in @a field from section @a section_name
@@ -110,7 +110,7 @@ public:
      * On success, value holds pointer to null terminated string.
      * Caller must free the memory allocated for value
      */
-    int extract_options(const char *section_name, const char *key, char **value);
+    int extract_options(const char *section_name, const char *key, char **value) const;
 
     /**
      * Get next section name from iterator that matches the shell wildcard @a pattern.
@@ -147,15 +147,15 @@ private:
     struct section *_sections;
 
     int _parse_file(const char *addr, size_t len, const char *filename);
-    struct section *_find_section(const char *section_name, size_t len);
-    struct config *_find_config(struct section *s, const char *key_name, size_t key_len);
+    struct section *_find_section(const char *section_name, size_t len) const;
+    struct config *_find_config(struct section *s, const char *key_name, size_t key_len) const;
 
     struct section *_add_section(const char *addr, size_t len, int line, const char *filename);
     int _add_config(struct section *s, const char *entry, size_t entry_len, const char *filename,
                     int line);
     void _trim(const char **str, size_t *len);
     int _extract_options_from_section(struct section *s, const OptionsTable table[],
-                                      size_t table_len, void *data);
+                                      size_t table_len, void *data) const;
 };
 
 /*

--- a/src/gstreamer_pipeline_builder.cpp
+++ b/src/gstreamer_pipeline_builder.cpp
@@ -42,7 +42,7 @@ static int parse_stl_string(const char *val, size_t val_len, void *storage, size
     return 0;
 }
 
-void GstreamerPipelineBuilder::apply_configs(ConfFile &conf)
+void GstreamerPipelineBuilder::apply_configs(const ConfFile &conf)
 {
     static const ConfFile::OptionsTable option_table[] = {
         {"encoder", false, parse_stl_string, OPTIONS_TABLE_STRUCT_FIELD(options, encoder)},

--- a/src/gstreamer_pipeline_builder.h
+++ b/src/gstreamer_pipeline_builder.h
@@ -24,7 +24,7 @@
 class GstreamerPipelineBuilder {
 public:
     virtual ~GstreamerPipelineBuilder() {}
-    void apply_configs(ConfFile &conf);
+    void apply_configs(const ConfFile &conf);
     std::string create_caps(std::map<std::string, std::string> &params);
     std::string create_muxer(std::map<std::string, std::string> &params);
     std::string create_converter(std::map<std::string, std::string> &params);

--- a/src/mavlink_server.cpp
+++ b/src/mavlink_server.cpp
@@ -35,7 +35,7 @@ using namespace std::placeholders;
 
 static const float epsilon = std::numeric_limits<float>::epsilon();
 
-MavlinkServer::MavlinkServer(ConfFile &conf, std::vector<std::unique_ptr<Stream>> &streams,
+MavlinkServer::MavlinkServer(const ConfFile &conf, std::vector<std::unique_ptr<Stream>> &streams,
                              RTSPServer &rtsp)
     : _streams(streams)
     , _is_running(false)

--- a/src/mavlink_server.h
+++ b/src/mavlink_server.h
@@ -35,7 +35,8 @@ typedef struct image_callback {
 
 class MavlinkServer {
 public:
-    MavlinkServer(ConfFile &conf, std::vector<std::unique_ptr<Stream>> &streams, RTSPServer &rtsp);
+    MavlinkServer(const ConfFile &conf, std::vector<std::unique_ptr<Stream>> &streams,
+                  RTSPServer &rtsp);
     ~MavlinkServer();
     void start();
     void stop();

--- a/src/stream_builder.h
+++ b/src/stream_builder.h
@@ -20,7 +20,7 @@
 
 class StreamBuilder {
 public:
-    virtual std::vector<Stream *> build_streams(ConfFile &conf) = 0;
+    virtual std::vector<Stream *> build_streams(const ConfFile &conf) = 0;
     virtual ~StreamBuilder();
     static std::vector<StreamBuilder *> &get_builders();
 

--- a/src/stream_builder_aero_bottom.cpp
+++ b/src/stream_builder_aero_bottom.cpp
@@ -20,7 +20,7 @@
 
 static StreamBuilderAeroBottom stream_builder;
 
-std::vector<Stream *> StreamBuilderAeroBottom::build_streams(ConfFile &conf)
+std::vector<Stream *> StreamBuilderAeroBottom::build_streams(const ConfFile &conf)
 {
     std::vector<Stream *> streams;
 

--- a/src/stream_builder_aero_bottom.h
+++ b/src/stream_builder_aero_bottom.h
@@ -27,5 +27,5 @@ public:
     }
     ~StreamBuilderAeroBottom() {}
 
-    std::vector<Stream *> build_streams(ConfFile &conf);
+    std::vector<Stream *> build_streams(const ConfFile &conf);
 };

--- a/src/stream_builder_realsense.cpp
+++ b/src/stream_builder_realsense.cpp
@@ -22,7 +22,7 @@
 
 static StreamBuilderRealsense stream_builder;
 
-std::vector<Stream *> StreamBuilderRealsense::build_streams(ConfFile &conf)
+std::vector<Stream *> StreamBuilderRealsense::build_streams(const ConfFile &conf)
 {
     std::vector<Stream *> streams;
 

--- a/src/stream_builder_realsense.h
+++ b/src/stream_builder_realsense.h
@@ -27,5 +27,5 @@ public:
     }
     ~StreamBuilderRealsense() {}
 
-    std::vector<Stream *> build_streams(ConfFile &conf);
+    std::vector<Stream *> build_streams(const ConfFile &conf);
 };

--- a/src/stream_builder_v4l2.cpp
+++ b/src/stream_builder_v4l2.cpp
@@ -30,7 +30,7 @@
 
 static StreamBuilderV4l2 stream_builder;
 
-std::vector<Stream *> StreamBuilderV4l2::build_streams(ConfFile &conf)
+std::vector<Stream *> StreamBuilderV4l2::build_streams(const ConfFile &conf)
 {
     DIR *dir;
     struct dirent *f;

--- a/src/stream_builder_v4l2.h
+++ b/src/stream_builder_v4l2.h
@@ -27,5 +27,5 @@ public:
     }
     ~StreamBuilderV4l2() {}
 
-    std::vector<Stream *> build_streams(ConfFile &conf);
+    std::vector<Stream *> build_streams(const ConfFile &conf);
 };

--- a/src/stream_manager.cpp
+++ b/src/stream_manager.cpp
@@ -27,7 +27,7 @@
 #define DEFAULT_SERVICE_PORT 8554
 #define DEFAULT_SERVICE_TYPE "_rtsp._udp"
 
-StreamManager::StreamManager(ConfFile &conf)
+StreamManager::StreamManager(const ConfFile &conf)
     : is_running(false)
 #ifdef ENABLE_AVAHI
     , avahi_publisher(streams, DEFAULT_SERVICE_PORT, DEFAULT_SERVICE_TYPE)

--- a/src/stream_manager.h
+++ b/src/stream_manager.h
@@ -34,7 +34,7 @@
 
 class StreamManager {
 public:
-    StreamManager(ConfFile &conf);
+    StreamManager(const ConfFile &conf);
     ~StreamManager();
     void start();
     void stop();

--- a/test/stream_builder_custom.cpp
+++ b/test/stream_builder_custom.cpp
@@ -20,7 +20,7 @@
 
 static StreamBuilderCustom stream_builder;
 
-std::vector<Stream *> StreamBuilderCustom::build_streams(ConfFile &conf)
+std::vector<Stream *> StreamBuilderCustom::build_streams(const ConfFile &conf)
 {
     std::vector<Stream *> streams;
 

--- a/test/stream_builder_custom.h
+++ b/test/stream_builder_custom.h
@@ -27,5 +27,5 @@ public:
     }
     ~StreamBuilderCustom() {}
 
-    std::vector<Stream *> build_streams(ConfFile &conf);
+    std::vector<Stream *> build_streams(const ConfFile &conf);
 };


### PR DESCRIPTION
It is recommended to use `const` qualifier for parameters if they're used in read-only manner. `ConfFile` instance is used as read-only, hence made it as `const` wherever applicable.

This commit constfiy selector ethods in classes `CameraServer`, `ConfFile` and `MavlinkServer`. Clang formatter was run on this commit.